### PR TITLE
Added license key for build tools 28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -s https://dl.google.com/android/repository/sdk-tools-linux-${VERSION_S
     rm -v /sdk.zip
 
 RUN mkdir -p $ANDROID_HOME/licenses/ \
-  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" > $ANDROID_HOME/licenses/android-sdk-license \
+  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license \
   && echo "84831b9409646a918e30573bab4c9c91346d8abd\n504667f4c0de7af1a06de9f4b1727b84351f2910" > $ANDROID_HOME/licenses/android-sdk-preview-license
 
 ADD packages.txt /sdk


### PR DESCRIPTION
This change fixes the following error
````
Checking the license for package Android SDK Build-Tools 28.0.2 in /sdk/licenses
Warning: License for package Android SDK Build-Tools 28.0.2 not accepted.
Checking the license for package Android SDK Platform 27 in /sdk/licenses
Warning: License for package Android SDK Platform 27 not accepted.
````